### PR TITLE
cryptoapi: add flags for physical store and logical store

### DIFF
--- a/cryptoapi_windows.go
+++ b/cryptoapi_windows.go
@@ -31,7 +31,7 @@ var (
 		"current-user": Store{registry.CURRENT_USER, `SOFTWARE\Microsoft\SystemCertificates`, `%s\Certificates`},
 		"system":       Store{registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\SystemCertificates`, `%s\Certificates`},
 		"enterprise":   Store{registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\EnterpriseCertificates`, `%s\Certificates`},
-		"group-policy": Store{registry.LOCAL_MACHINE, `SOFTWARE\Policy\Microsoft\SystemCertificates`, `%s\Certificates`},
+		"group-policy": Store{registry.LOCAL_MACHINE, `SOFTWARE\Policies\Microsoft\SystemCertificates`, `%s\Certificates`},
 	}
 )
 

--- a/cryptoapi_windows.go
+++ b/cryptoapi_windows.go
@@ -9,16 +9,66 @@ import (
 	"time"
 
 	"golang.org/x/sys/windows/registry"
+	"gopkg.in/hlandau/easyconfig.v1/cflag"
 )
 
-// In 64-bit Windows, this key is shared between 64-bit and 32-bit applications.
-// See https://msdn.microsoft.com/en-us/library/windows/desktop/aa384253.aspx
-const cryptoApiCertStoreRegistryBase = registry.LOCAL_MACHINE
-const cryptoApiCertStoreRegistryKey = `SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates`
+var (
+	cryptoApiFlagGroup            = cflag.NewGroup(flagGroup, "capi")
+	cryptoApiFlagLogicalStoreName = cflag.String(cryptoApiFlagGroup, "logical-store", "Root",
+		"Name of CryptoAPI logical store to inject certificate into. Consider: Root, Trust, CA, My")
+	cryptoApiFlagPhysicalStoreName = cflag.String(cryptoApiFlagGroup, "physical-store", "system",
+		"Scope of CryptoAPI certificate store. Valid choices: current-user, system, enterprise, group-policy")
+)
+
 const cryptoApiMagicName = "Namecoin"
 const cryptoApiMagicValue = 1
 
+var (
+	// cryptoApiStores consists of every implemented store.
+	// when adding a new one, the `%s` variable is optional.
+	// if `%s` exists in the Logical string, it is replaced with the value of -store flag
+	cryptoApiStores = map[string]Store{
+		"current-user": Store{registry.CURRENT_USER, `SOFTWARE\Microsoft\SystemCertificates`, `%s\Certificates`},
+		"system":       Store{registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\SystemCertificates`, `%s\Certificates`},
+		"enterprise":   Store{registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\EnterpriseCertificates`, `%s\Certificates`},
+		"group-policy": Store{registry.LOCAL_MACHINE, `SOFTWARE\Policy\Microsoft\SystemCertificates`, `%s\Certificates`},
+	}
+)
+
+// Store is used to generate a key to open a certificate store in the Windows Registry
+type Store struct {
+	Base     registry.Key
+	Physical string
+	Logical  string // may contain a %s, in which it would be replaced by the -store flag
+}
+
+// String human readable string, only useful for debug logs
+func (s Store) String() string {
+	return fmt.Sprintf(`%s\%s\`+s.Logical, s.Base, s.Physical, cryptoApiFlagLogicalStoreName.Value())
+}
+
+// Key generates the registry key for use in opening the store
+func (s Store) Key() string {
+	return fmt.Sprintf(`%s\`+s.Logical, s.Physical, cryptoApiFlagLogicalStoreName.Value())
+}
+
+// cryptoApiNameToStore checks that the choice is valid before returning a complete Store request
+func cryptoApiNameToStore(name string) (Store, error) {
+	store, ok := cryptoApiStores[name]
+	if !ok {
+		return Store{}, fmt.Errorf("invalid choice for physical store, consider: current-user, system, enterprise, group-policy")
+	}
+	return store, nil
+}
+
 func injectCertCryptoApi(derBytes []byte) {
+	store, err := cryptoApiNameToStore(cryptoApiFlagPhysicalStoreName.Value())
+	if err != nil {
+		log.Errorf("error: %s", err.Error())
+		return
+	}
+	registryBase := store.Base
+	storeKey := store.Key()
 
 	// Format documentation of Microsoft's "Certificate Registry Blob":
 
@@ -65,13 +115,20 @@ func injectCertCryptoApi(derBytes []byte) {
 	certLength := len(derBytes)
 
 	// Header for a stripped Windows Certificate Registry Blob
-	certBlobHeader := []byte{0x20, 0, 0, 0, 0x01, 0, 0, 0, byte((certLength >> 0) & 0xFF), byte((certLength >> 8) & 0xFF), byte((certLength >> 16) & 0xFF), byte((certLength >> 24) & 0xFF)}
+	certBlobHeader := []byte{
+		0:  0x20,
+		4:  0x01,
+		8:  byte((certLength >> 0) & 0xFF),
+		9:  byte((certLength >> 8) & 0xFF),
+		10: byte((certLength >> 16) & 0xFF),
+		11: byte((certLength >> 24) & 0xFF),
+	}
 
 	// Construct the Blob
 	certBlob := append(certBlobHeader, derBytes...)
 
 	// Open up the cert store.
-	certStoreKey, err := registry.OpenKey(cryptoApiCertStoreRegistryBase, cryptoApiCertStoreRegistryKey, registry.ALL_ACCESS)
+	certStoreKey, err := registry.OpenKey(registryBase, storeKey, registry.ALL_ACCESS)
 	if err != nil {
 		log.Errorf("Couldn't open cert store: %s", err)
 		return
@@ -121,9 +178,16 @@ func injectCertCryptoApi(derBytes []byte) {
 }
 
 func cleanCertsCryptoApi() {
+	store, err := cryptoApiNameToStore(cryptoApiFlagPhysicalStoreName.Value())
+	if err != nil {
+		log.Errorf("error: %s", err.Error())
+		return
+	}
+	registryBase := store.Base
+	storeKey := store.Key()
 
 	// Open up the cert store.
-	certStoreKey, err := registry.OpenKey(cryptoApiCertStoreRegistryBase, cryptoApiCertStoreRegistryKey, registry.ALL_ACCESS)
+	certStoreKey, err := registry.OpenKey(registryBase, storeKey, registry.ALL_ACCESS)
 	if err != nil {
 		log.Errorf("Couldn't open cert store: %s", err)
 		return

--- a/cryptoapi_windows.go
+++ b/cryptoapi_windows.go
@@ -15,7 +15,7 @@ import (
 var (
 	cryptoApiFlagGroup            = cflag.NewGroup(flagGroup, "capi")
 	cryptoApiFlagLogicalStoreName = cflag.String(cryptoApiFlagGroup, "logical-store", "Root",
-		"Name of CryptoAPI logical store to inject certificate into. Consider: Root, Trust, CA, My")
+		"Name of CryptoAPI logical store to inject certificate into. Consider: Root, Trust, CA, My, Disallowed")
 	cryptoApiFlagPhysicalStoreName = cflag.String(cryptoApiFlagGroup, "physical-store", "system",
 		"Scope of CryptoAPI certificate store. Valid choices: current-user, system, enterprise, group-policy")
 )

--- a/cryptoapi_windows_test.go
+++ b/cryptoapi_windows_test.go
@@ -12,7 +12,7 @@ func TestRegistryKeyNames(t *testing.T) {
 	tests := []struct {
 		Name     string // for logs
 		Physical string // from user flag
-		Logical  string // from userflag
+		Logical  string // from user flag
 		Key      string // registry
 		Base     registry.Key
 	}{
@@ -20,6 +20,7 @@ func TestRegistryKeyNames(t *testing.T) {
 		{"system+CA", "system", "CA", `SOFTWARE\Microsoft\SystemCertificates\CA\Certificates`, lm},
 		{"system+My", "system", "My", `SOFTWARE\Microsoft\SystemCertificates\My\Certificates`, lm},
 		{"system+Trust", "system", "Trust", `SOFTWARE\Microsoft\SystemCertificates\Trust\Certificates`, lm},
+		{"system+Disallowed", "system", "Disallowed", `SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates`, lm},
 		{"user+root", "current-user", "Root", `SOFTWARE\Microsoft\SystemCertificates\Root\Certificates`, cu},
 		{"user+CA", "current-user", "CA", `SOFTWARE\Microsoft\SystemCertificates\CA\Certificates`, cu},
 		{"user+My", "current-user", "My", `SOFTWARE\Microsoft\SystemCertificates\My\Certificates`, cu},

--- a/cryptoapi_windows_test.go
+++ b/cryptoapi_windows_test.go
@@ -28,10 +28,10 @@ func TestRegistryKeyNames(t *testing.T) {
 		{"enterprise+CA", "enterprise", "CA", `SOFTWARE\Microsoft\EnterpriseCertificates\CA\Certificates`, lm},
 		{"enterprise+My", "enterprise", "My", `SOFTWARE\Microsoft\EnterpriseCertificates\My\Certificates`, lm},
 		{"enterprise+Trust", "enterprise", "Trust", `SOFTWARE\Microsoft\EnterpriseCertificates\Trust\Certificates`, lm},
-		{"group+root", "group-policy", "Root", `SOFTWARE\Policy\Microsoft\SystemCertificates\Root\Certificates`, lm},
-		{"group+CA", "group-policy", "CA", `SOFTWARE\Policy\Microsoft\SystemCertificates\CA\Certificates`, lm},
-		{"group+My", "group-policy", "My", `SOFTWARE\Policy\Microsoft\SystemCertificates\My\Certificates`, lm},
-		{"group+Trust", "group-policy", "Trust", `SOFTWARE\Policy\Microsoft\SystemCertificates\Trust\Certificates`, lm},
+		{"group+root", "group-policy", "Root", `SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates`, lm},
+		{"group+CA", "group-policy", "CA", `SOFTWARE\Policies\Microsoft\SystemCertificates\CA\Certificates`, lm},
+		{"group+My", "group-policy", "My", `SOFTWARE\Policies\Microsoft\SystemCertificates\My\Certificates`, lm},
+		{"group+Trust", "group-policy", "Trust", `SOFTWARE\Policies\Microsoft\SystemCertificates\Trust\Certificates`, lm},
 	}
 	for _, tc := range tests {
 		store, ok := cryptoApiStores[tc.Physical]

--- a/cryptoapi_windows_test.go
+++ b/cryptoapi_windows_test.go
@@ -1,0 +1,71 @@
+package certinject
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func TestRegistryKeyNames(t *testing.T) {
+	cu := registry.CURRENT_USER
+	lm := registry.LOCAL_MACHINE
+	tests := []struct {
+		Name     string // for logs
+		Physical string // from user flag
+		Logical  string // from userflag
+		Key      string // registry
+		Base     registry.Key
+	}{
+		{"system+root", "system", "Root", `SOFTWARE\Microsoft\SystemCertificates\Root\Certificates`, lm},
+		{"system+CA", "system", "CA", `SOFTWARE\Microsoft\SystemCertificates\CA\Certificates`, lm},
+		{"system+My", "system", "My", `SOFTWARE\Microsoft\SystemCertificates\My\Certificates`, lm},
+		{"system+Trust", "system", "Trust", `SOFTWARE\Microsoft\SystemCertificates\Trust\Certificates`, lm},
+		{"user+root", "current-user", "Root", `SOFTWARE\Microsoft\SystemCertificates\Root\Certificates`, cu},
+		{"user+CA", "current-user", "CA", `SOFTWARE\Microsoft\SystemCertificates\CA\Certificates`, cu},
+		{"user+My", "current-user", "My", `SOFTWARE\Microsoft\SystemCertificates\My\Certificates`, cu},
+		{"user+Trust", "current-user", "Trust", `SOFTWARE\Microsoft\SystemCertificates\Trust\Certificates`, cu},
+		{"enterprise+root", "enterprise", "Root", `SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates`, lm},
+		{"enterprise+CA", "enterprise", "CA", `SOFTWARE\Microsoft\EnterpriseCertificates\CA\Certificates`, lm},
+		{"enterprise+My", "enterprise", "My", `SOFTWARE\Microsoft\EnterpriseCertificates\My\Certificates`, lm},
+		{"enterprise+Trust", "enterprise", "Trust", `SOFTWARE\Microsoft\EnterpriseCertificates\Trust\Certificates`, lm},
+		{"group+root", "group-policy", "Root", `SOFTWARE\Policy\Microsoft\SystemCertificates\Root\Certificates`, lm},
+		{"group+CA", "group-policy", "CA", `SOFTWARE\Policy\Microsoft\SystemCertificates\CA\Certificates`, lm},
+		{"group+My", "group-policy", "My", `SOFTWARE\Policy\Microsoft\SystemCertificates\My\Certificates`, lm},
+		{"group+Trust", "group-policy", "Trust", `SOFTWARE\Policy\Microsoft\SystemCertificates\Trust\Certificates`, lm},
+	}
+	for _, tc := range tests {
+		store, ok := cryptoApiStores[tc.Physical]
+		if !ok {
+			t.Errorf("test %q is invalid (store not defined)", tc.Physical)
+			continue
+		}
+		if err := cryptoApiFlagLogicalStoreName.CfSetValue(tc.Logical); err != nil {
+			t.Errorf("test %q: %v", tc.Name, err)
+			continue
+		}
+		key := store.Key()
+		base := store.Base
+		if key != tc.Key {
+			t.Errorf("test %q: expected key to be %q, got %q", tc.Name, tc.Key, key)
+			continue
+		}
+
+		base2str := func(t *testing.T, r registry.Key) string {
+			switch r {
+			case cu:
+				return "HKCU"
+			case lm:
+				return "HKLM"
+			default:
+				t.Errorf("expected valid registry key, got: %v", r)
+				t.FailNow()
+				return ""
+			}
+		}
+		if base != tc.Base {
+			t.Errorf("test %q: expected base to be %v, got %v", tc.Name, base2str(t, tc.Base), base2str(t, base))
+			continue
+		}
+		t.Logf("[PASS] test %q: %s\\%s", tc.Name, base2str(t, base), key)
+	}
+}


### PR DESCRIPTION
Closes #2 

  * `--capi.physical-store <name>` names the physical store to inject certificate into
    * (default: `system`)
    * allows only `system`, `current-user`, `enterprise`, and `group-policy`

  * `--capi.logical-store <store-name>` names the logical store to inject certificate into.
    *  (default: `Root`)
    * allows `Root`, `Trust`, `CA`, `My`, `Disallowed` or any other custom string

Currently, only `system` + `Root` combo passes the powershell test (testdata/ci-failtest.ps1)