### PR TITLE
add golangci-linter, simplify travis.yml, delint some small stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ env:
   global:
     # GITHUB_TOKEN for automatic releases
     - secure: "at1oJs7ib7glx3W+zk+OkT041LdknVXirIhN403CIihVUrlOhODY7yCTgvF4Rk0jYBJiT35Q2qxpgfWF2qGnsNsQmjG3ydDWQDCepDc/CgXfLyoiSTJK5vTK72dYWTVsBTycXbj1CbSy2X2ah/KWjc4RcgZ67ER7mDpRU5nFeow="
-      # Set this to the Go version to use for releases (must appear in version list above).
+    # Set this to the Go version to use for releases (must appear in version list above).
     - RELEASE_GO_VERSION="1.x"
-      # Go versions before go1.13.x will grab master branch unless we use GO111MODULE=on
-      # (go1.10.x still needs the above workaround)
+    # Go versions before go1.13.x will grab master branch unless we use GO111MODULE=on
+    # (go1.10.x still needs the workaround in testdata/travis.bash)
     - GO111MODULE="on"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,24 @@ jobs:
     - stage: lint
   include:
     - os: linux
+      stage: lint-new
+      language: go
+      go: "1.14.x"
+      script:
+        # lint new changes
+        - go get -v -d -t ./...
+        - bash testdata/golangci-linter.bash --new-from-rev=HEAD~ # new changes
+    - os: linux
       stage: lint
       language: go
       go: "1.14.x"
       script:
         # lint stage
         - go get -v -d -t ./...
-        - bash testdata/golangci-linter.bash
+        - bash testdata/golangci-linter.bash # all, allowed to fail
 
 stages:
+  - lint-new
   - lint
   - test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 os:
-  - linux
   - windows
+  - linux
 go:
   - "1.10.x"
   - "1.11.x"
@@ -19,14 +19,34 @@ notifications:
       - "chat.freenode.net#namecoin-dev"
     on_success: never
 
+jobs:
+  allow_failures:
+    - stage: lint
+  include:
+    - os: linux
+      stage: lint
+      language: go
+      go: "1.14.x"
+      script:
+        # lint stage
+        - go get -v -d -t ./...
+        - bash testdata/golangci-linter.bash
+
+stages:
+  - lint
+  - test
+
+# 'test' stage
 script:
-  - if [ "$TRAVIS_OS_NAME" = 'windows' ]; then bash testdata/travis.bash; fi
-  - go get -v -d -t ./...
-  - go test -v ./...
+  - env
+  - bash testdata/travis.bash
 
 env:
   global:
     # GITHUB_TOKEN for automatic releases
     - secure: "at1oJs7ib7glx3W+zk+OkT041LdknVXirIhN403CIihVUrlOhODY7yCTgvF4Rk0jYBJiT35Q2qxpgfWF2qGnsNsQmjG3ydDWQDCepDc/CgXfLyoiSTJK5vTK72dYWTVsBTycXbj1CbSy2X2ah/KWjc4RcgZ67ER7mDpRU5nFeow="
-    # Set this to the Go version to use for releases (must appear in version list above).
+      # Set this to the Go version to use for releases (must appear in version list above).
     - RELEASE_GO_VERSION="1.x"
+      # Go versions before go1.13.x will grab master branch unless we use GO111MODULE=on
+      # (go1.10.x still needs the above workaround)
+    - GO111MODULE="on"

--- a/certinject.go
+++ b/certinject.go
@@ -5,9 +5,8 @@ import (
 	"gopkg.in/hlandau/easyconfig.v1/cflag"
 )
 
-var log, Log = xlog.New("ncdns.certinject")
-
 var (
+	log, logp        = xlog.New("ncdns.certinject")
 	flagGroup        = cflag.NewGroup(nil, "certstore")
 	nssFlag          = cflag.Bool(flagGroup, "nss", false, nssExplain)
 	certExpirePeriod = cflag.Int(flagGroup, "expire", 60*30, "Duration "+
@@ -15,3 +14,8 @@ var (
 		"trust store.  Making this smaller than the DNS TTL (default "+
 		"600) may cause TLS errors.")
 )
+
+// SetLogLevel allows an application to set a log level
+func SetLogLevel(level xlog.Severity) {
+	logp.SetSeverity(level)
+}

--- a/certinject.go
+++ b/certinject.go
@@ -15,7 +15,7 @@ var (
 		"600) may cause TLS errors.")
 )
 
-// SetLogLevel allows an application to set a log level
+// SetLogLevel allows an application to set a log level.
 func SetLogLevel(level xlog.Severity) {
 	logp.SetSeverity(level)
 }

--- a/certinject_windows.go
+++ b/certinject_windows.go
@@ -21,10 +21,10 @@ var (
 
 // InjectCert injects the given cert into all configured trust stores.
 func InjectCert(derBytes []byte) {
-
 	if cryptoApiFlag.Value() {
 		injectCertCryptoApi(derBytes)
 	}
+
 	if nssFlag.Value() {
 		injectCertNss(derBytes)
 	}
@@ -32,12 +32,11 @@ func InjectCert(derBytes []byte) {
 
 // CleanCerts cleans expired certs from all configured trust stores.
 func CleanCerts() {
-
 	if cryptoApiFlag.Value() {
 		cleanCertsCryptoApi()
 	}
+
 	if nssFlag.Value() {
 		cleanCertsNss()
 	}
-
 }

--- a/cmd/certinject/main.go
+++ b/cmd/certinject/main.go
@@ -19,7 +19,8 @@ func main() {
 	var (
 		flagGroup = cflag.NewGroup(nil, "certinject")
 		certflag  = cflag.String(flagGroup, "cert", "", "path to certificate to inject into trust store")
-		loglevel  = cflag.String(flagGroup, "loglevel", "info", "logging level (from least to most verbose: emergency, alert, critical, error, warn, notice, info, debug, trace")
+		loglevel  = cflag.String(flagGroup, "loglevel", "info",
+			"logging level (from least to most verbose: emergency, alert, critical, error, warn, notice, info, debug, trace")
 	)
 
 	// read config
@@ -32,22 +33,28 @@ func main() {
 	if !ok {
 		log.Fatal("invalid log level, valid log levels: emergency, alert, critical, error, warn, notice, info, debug, trace")
 	}
-	certinject.Log.SetSeverity(level)
+
+	certinject.SetLogLevel(level)
 	logp.SetSeverity(level)
 
 	cert := certflag.Value()
 	if cert == "" {
 		log.Fatal("no certificate to add")
 	}
+
 	log.Debugf("reading certificate: %q", cert)
+
 	b, err := ioutil.ReadFile(cert)
 	if err != nil {
 		log.Fatale(err, "error reading certificate")
 	}
+
 	if p, err := pem.Decode(b); err == nil {
-		log.Debugf("user provided PEM encoded certificate, extracting DER bytes")
 		b = p.Bytes
+
+		log.Debugf("user provided PEM encoded certificate, extracting DER bytes")
 	}
+
 	certinject.InjectCert(b)
 	log.Debugf("injected certificate: %q", cert)
 }

--- a/file.go
+++ b/file.go
@@ -7,8 +7,8 @@ import (
 
 // Injects a certificate by writing to a file.  Might be relevant for non-CryptoAPI trust stores.
 func injectCertFile(derBytes []byte, fileName string) {
-
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
 	err := ioutil.WriteFile(fileName, pemBytes, 0644)
 	if err != nil {
 		log.Errore(err, "Error writing cert!")

--- a/testdata/golangci-linter.bash
+++ b/testdata/golangci-linter.bash
@@ -12,13 +12,13 @@ echo ----- Windows -----
 GOOS=windows $(go env GOPATH)/bin/golangci-lint run --no-config --enable-all \
   --color always \
   --disable gochecknoglobals,gomnd \
-  -v \
+  -v $@ \
   ./...
 
 echo ----- Linux -----
 GOOS=linux $(go env GOPATH)/bin/golangci-lint run --no-config --enable-all \
   --color always \
   --disable gochecknoglobals,gomnd \
-  -v \
+  -v $@ \
   ./...
 

--- a/testdata/golangci-linter.bash
+++ b/testdata/golangci-linter.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+golangci_linter_version=v1.27.0
+
+# fetch golangci-lint program
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${golangci_linter_version}
+
+# run linters
+GOOS=windows $(go env GOPATH)/bin/golangci-lint run --no-config --enable-all \
+  --color always \
+  --disable gochecknoglobals,gomnd \
+  -v \
+  ./...
+

--- a/testdata/golangci-linter.bash
+++ b/testdata/golangci-linter.bash
@@ -3,10 +3,20 @@
 golangci_linter_version=v1.27.0
 
 # fetch golangci-lint program
+
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${golangci_linter_version}
 
 # run linters
+
+echo ----- Windows -----
 GOOS=windows $(go env GOPATH)/bin/golangci-lint run --no-config --enable-all \
+  --color always \
+  --disable gochecknoglobals,gomnd \
+  -v \
+  ./...
+
+echo ----- Linux -----
+GOOS=linux $(go env GOPATH)/bin/golangci-lint run --no-config --enable-all \
   --color always \
   --disable gochecknoglobals,gomnd \
   -v \

--- a/testdata/travis.bash
+++ b/testdata/travis.bash
@@ -1,6 +1,26 @@
+#!/bin/bash
 set -ex
+
+# workaround for go1.10's no module support, we copy this run's source code into namecoin/certinject
+if [ "$TRAVIS_REPO_SLUG" != "namecoin/certinject" ] && [ "$TRAVIS_GO_VERSION" = "1.10.x" ]; then
+  mkdir $GOPATH/src/github.com/namecoin && \
+  cp -av . $GOPATH/src/github.com/namecoin/certinject && \
+  cd $GOPATH/src/github.com/namecoin/certinject
+fi
+
+echo Fetching dependencies
 go get -v -u -t ./...
+
+echo Building certinject.exe
 go build -o certinject.exe ./cmd/certinject
+
+if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+echo Running powershell tests
 powershell -ExecutionPolicy Unrestricted -File "testdata/ci-failtest.ps1"
+fi
+
+echo Testing config parsing
 ./certinject.exe -conf testdata/test.conf
+
+echo Running go test suite
 go test -v ./...

--- a/testdata/travis.bash
+++ b/testdata/travis.bash
@@ -1,15 +1,24 @@
 #!/bin/bash
 set -ex
 
-# workaround for go1.10's no module support, we copy this run's source code into namecoin/certinject
-if [ "$TRAVIS_REPO_SLUG" != "namecoin/certinject" ] && [ "$TRAVIS_GO_VERSION" = "1.10.x" ]; then
+# set GOPATH if empty (travis sets it, but useful for humans)
+if [ -z "$GOPATH" ]; then
+export GOPATH=$(go env GOPATH)
+fi
+
+# workaround for go1.10's no module support, we copy this run's source code
+# into $GOPATH/src/github.com/namecoin/certinject to avoid downloading our master branch.
+#
+# this only affects forks running travis runs. ( Pull requests and autobuilds
+# will clone into: PWD=/c/Users/travis/gopath/src/github.com/namecoin/certinject )
+if [ "$TRAVIS_GO_VERSION" = "1.10.x" ] && [ ! -d $GOPATH/src/github.com/namecoin/certinject ]; then
   mkdir $GOPATH/src/github.com/namecoin && \
-  cp -av . $GOPATH/src/github.com/namecoin/certinject && \
+  cp -av $PWD $GOPATH/src/github.com/namecoin/certinject && \
   cd $GOPATH/src/github.com/namecoin/certinject
 fi
 
 echo Fetching dependencies
-go get -v -u -t ./...
+go get -v -t ./...
 
 echo Building certinject.exe
 go build -o certinject.exe ./cmd/certinject


### PR DESCRIPTION
Reorder OS tests, so that we run the Windows tests first.

Simplify travis.yml, make all OS run testdata/travis.bash (where it's easier to switch on conditions)

Simplify error check in nss.go

Miscellaneous whitespace-related delinting, left some non-trivial things for another time/place

Since Go module support was added in Go 1.11... the Go 1.10 tests we weren't using the pull request's source code (we were fetching master branch of this repo). To workaround this, we copy the source into `$GOPATH/src/github.com/namecoin/certinject` to avoid downloading the master branch. This only happens in Go 1.10 test run. For go 1.11 and 1.12, we set GO111MODULE to activate go module support. (its active by default in newer versions)

Add a **lint** stage, which runs golangci-linter. It's allowed to fail for now, but the travis build logs are helpful.