### PR TITLE
Remove env from Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ stages:
 
 # 'test' stage
 script:
-  - env
   - bash testdata/travis.bash
 
 env:


### PR DESCRIPTION
Not sure why it was there originally, but it seems unwise to have it there in case we end up adding encrypted variables in the future.