### PR TITLE
Travis: switch IRC to OFTC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
   irc:
     if: repo = namecoin/certinject
     channels:
-      - "chat.freenode.net#namecoin-dev"
+      - "irc.oftc.net#namecoin-dev"
     on_success: never
 
 jobs:


### PR DESCRIPTION
OFTC is more Tor-friendly than Freenode, and should be our primary recommendation.