### PR TITLE
Cirrus: Mark "makezero" linter as non-mandatory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
         GOLANGCI_ARGS: "--new-from-rev=HEAD~"
     - name: Go Lint $GOOS Mandatory
       env:
-        GOLANGCI_ARGS: "--disable=errorlint,exhaustive,exhaustivestruct,gci,godot,gofumpt,nlreturn,paralleltest"
+        GOLANGCI_ARGS: "--disable=errorlint,exhaustive,exhaustivestruct,gci,godot,gofumpt,makezero,nlreturn,paralleltest"
     - name: Go Lint $GOOS
       env:
         GOLANGCI_ARGS: ""


### PR DESCRIPTION
This appears to be a new linter, and is breaking the master branch's Cirrus status.