### PR TITLE
Cirrus: mark errorlint as mandatory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
         GOLANGCI_ARGS: "--new-from-rev=HEAD~"
     - name: Go Lint $GOOS Mandatory
       env:
-        GOLANGCI_ARGS: "--disable=errorlint,exhaustive,makezero,paralleltest,thelper"
+        GOLANGCI_ARGS: "--disable=exhaustive,makezero,paralleltest,thelper"
     - name: Go Lint $GOOS
       env:
         GOLANGCI_ARGS: ""


### PR DESCRIPTION
It wasn't currently producing any warnings anyway.