### PR TITLE
Remove outdated help text

### DIFF
--- a/certinject_windows.go
+++ b/certinject_windows.go
@@ -9,13 +9,7 @@ import (
 // Currently only supports Windows CryptoAPI and NSS sqlite3 stores.
 
 var cryptoAPIFlag = cflag.Bool(flagGroup, "cryptoapi", false,
-	"Synchronize TLS certs to the CryptoAPI trust store?  This "+
-		"enables HTTPS to work with Chromium/Chrome.  Only "+
-		"use if you've set up NUMS HPKP in Chromium/Chrome "+
-		"as per documentation.  If you haven't set up NUMS "+
-		"HPKP, or if you access ncdns from browsers not "+
-		"based on Chromium or Firefox, this is unsafe and "+
-		"should not be used.")
+	"Synchronize TLS certs to the CryptoAPI trust store.")
 
 // InjectCert injects the given cert into all configured trust stores.
 func InjectCert(derBytes []byte) {


### PR DESCRIPTION
We no longer use HPKP for negative overrides in Chromium; our current negative overrides should work globally in CryptoAPI.

Refs https://github.com/namecoin/certinject/issues/74